### PR TITLE
Adjustable http_timeout to iaas

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+1.1.0 (2018-06-13)
+------------------
+
+* feature: adjustable timeout for http requests to iaas 
+
 1.0.1 (2018-06-08)
 ------------------
 

--- a/config/settings-openstack.example.yaml
+++ b/config/settings-openstack.example.yaml
@@ -20,6 +20,7 @@ defaults:
     user_domain_name: default    # for auth only
     image_owner_ids:
       - user
+    http_timeout: 10 # seconds
 
   healthcheck:
     driver: HttpHealthcheck

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ aiofiles>=0.3.2
 aiohttp>=3.0.0
 aiohttp-jinja2>=1.0.0
 aiohttp-jsonrpc>=0.1.0
-AsyncOpenStackClient==0.6.2
+AsyncOpenStackClient==0.6.3
 aiounittest>=1.1.0
 bidict>=0.17.2
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(name):
 
 setup(
     name="vmshepherd",
-    version="1.0.2",
+    version="1.1.0",
     author='Dreamlab - PaaS KRK',
     author_email='paas-support@dreamlab.pl',
     url='https://github.com/Dreamlab/vmshepherd',

--- a/src/vmshepherd/iaas/openstack_driver.py
+++ b/src/vmshepherd/iaas/openstack_driver.py
@@ -42,8 +42,8 @@ class OpenStackDriver(AbstractIaasDriver):
                                          project_domain_name=self.config['project_domain_name'])
                 self.nova = NovaClient(session=self.auth)
                 self.glance = GlanceClient(session=self.auth)
-                await self.nova.init_api(timeout=self.config['http_timeout'])
-                await self.glance.init_api(timeout=self.config['http_timeout'])
+                await self.nova.init_api(timeout=self.config.get('http_timeout', 10))
+                await self.glance.init_api(timeout=self.config.get('http_timeout', 10))
 
             if not hasattr(self, 'last_init') or self.last_init < (time.time() - 60):
                 await self.initialize()

--- a/src/vmshepherd/iaas/openstack_driver.py
+++ b/src/vmshepherd/iaas/openstack_driver.py
@@ -42,8 +42,8 @@ class OpenStackDriver(AbstractIaasDriver):
                                          project_domain_name=self.config['project_domain_name'])
                 self.nova = NovaClient(session=self.auth)
                 self.glance = GlanceClient(session=self.auth)
-                await self.nova.init_api()
-                await self.glance.init_api()
+                await self.nova.init_api(timeout=self.config['http_timeout'])
+                await self.glance.init_api(timeout=self.config['http_timeout'])
 
             if not hasattr(self, 'last_init') or self.last_init < (time.time() - 60):
                 await self.initialize()


### PR DESCRIPTION
Since `AsyncOpenStackClient 0.6.3` provides adjustable http timeout, I set it up to 10s by default (library default is 60s which is a bit too much)