### PR TITLE
Render presets always in the same order

### DIFF
--- a/src/vmshepherd/http/templates/preset.html.jinja2
+++ b/src/vmshepherd/http/templates/preset.html.jinja2
@@ -1,4 +1,4 @@
-{% for name, data in presets.items() %}
+{% for name, data in sorted(presets.items()) %}
   <div class="preset-item" data-preset="{{ name }}">
     <h2 class="anchor" id="{{ name }}">Preset {{ name }}</h2>
     <div class="row">


### PR DESCRIPTION
This PR fixes order of presets rendering, before they were ordered at random, now they should appear always in the same sequence.