### PR TITLE
Feature/unique tmps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+1.3.2 (2019-07-26)
+------------------
+
+* bugfix:  Add unique name for a tmp preset directory in a Git Driver
+
+
 1.3.1 (2019-06-03)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(name):
 
 setup(
     name="vmshepherd",
-    version="1.3.1",
+    version="1.3.2",
     author='Dreamlab - PaaS KRK',
     author_email='paas-support@dreamlab.pl',
     url='https://github.com/Dreamlab/vmshepherd',

--- a/src/vmshepherd/presets/gitrepo_driver.py
+++ b/src/vmshepherd/presets/gitrepo_driver.py
@@ -2,7 +2,7 @@ import asyncio
 import errno
 import logging
 import os
-import tempfile
+from tempfile import NamedTemporaryFile
 from .abstract import AbstractConfigurationDriver
 from asyncio.subprocess import PIPE
 from vmshepherd.utils import async_load_from_yaml_file
@@ -12,7 +12,7 @@ class GitRepoDriver(AbstractConfigurationDriver):
 
     def __init__(self, config, runtime, defaults):
         super().__init__(runtime, defaults)
-        self._clone_dir = config.get('clone_dir', os.path.join(tempfile.gettempdir(), 'vmshepherd'))
+        self._clone_dir = config.get('clone_dir', NamedTemporaryFile(prefix='vmshepherd').name)
         self._repos = config['repositories']
         self._specs = {}
 

--- a/src/vmshepherd/presets/gitrepo_driver.py
+++ b/src/vmshepherd/presets/gitrepo_driver.py
@@ -2,7 +2,7 @@ import asyncio
 import errno
 import logging
 import os
-from tempfile import NamedTemporaryFile
+from tempfile import TemporaryDirectory
 from .abstract import AbstractConfigurationDriver
 from asyncio.subprocess import PIPE
 from vmshepherd.utils import async_load_from_yaml_file
@@ -12,7 +12,7 @@ class GitRepoDriver(AbstractConfigurationDriver):
 
     def __init__(self, config, runtime, defaults):
         super().__init__(runtime, defaults)
-        self._clone_dir = config.get('clone_dir', NamedTemporaryFile(prefix='vmshepherd').name)
+        self._clone_dir = config.get('clone_dir', TemporaryDirectory(prefix='vmshepherd').name)
         self._repos = config['repositories']
         self._specs = {}
 

--- a/src/vmshepherd/presets/gitrepo_driver.py
+++ b/src/vmshepherd/presets/gitrepo_driver.py
@@ -2,7 +2,7 @@ import asyncio
 import errno
 import logging
 import os
-from tempfile import TemporaryDirectory
+import tempfile
 from .abstract import AbstractConfigurationDriver
 from asyncio.subprocess import PIPE
 from vmshepherd.utils import async_load_from_yaml_file
@@ -12,7 +12,7 @@ class GitRepoDriver(AbstractConfigurationDriver):
 
     def __init__(self, config, runtime, defaults):
         super().__init__(runtime, defaults)
-        self._clone_dir = config.get('clone_dir', TemporaryDirectory(prefix='vmshepherd').name)
+        self._clone_dir = config.get('clone_dir', tempfile.TemporaryDirectory(prefix='vmshepherd').name)
         self._repos = config['repositories']
         self._specs = {}
 

--- a/tests/presets/test_gitrepo_driver.py
+++ b/tests/presets/test_gitrepo_driver.py
@@ -4,7 +4,6 @@ from unittest import mock
 from unittest.mock import Mock, patch
 from vmshepherd.presets import gitrepo_driver
 
-
 class MockItem:
 
     def __init__(self, path):
@@ -26,6 +25,10 @@ class TestGitRepo(AsyncTestCase):
             return_value=futurized(self.mock_process)
         ).start()
 
+        self.patch_tempfile = patch('vmshepherd.presets.gitrepo_driver.tempfile.NamedTemporaryFile')
+        self.mock_tmp = self.patch_tempfile.start()
+        self.mock_tmp.return_value.__enter__.return_value.name = '/tmp/vmshepherd123456'
+
         self.config = {
             'repositories': {
                 'paas': 'git://testrepm/paas.git',
@@ -34,6 +37,24 @@ class TestGitRepo(AsyncTestCase):
             'clone_dir': '/tmp/'
         }
         self.driver = gitrepo_driver.GitRepoDriver(self.config, self.mock_runtime, example_config['defaults'])
+
+    async def test_reload_tmp_path(self):
+        self.mock_os.path.exists.return_value = False
+        cfg = {
+            'repositories': {
+                'paas': 'git://testrepm/paas.git',
+                'db': 'git://stash/db.git',
+            }}
+        driver = gitrepo_driver.GitRepoDriver(cfg, self.mock_runtime, example_config['defaults'])
+        self.mock_os.path.join.side_effect = lambda a, b: (a + b)
+        driver._clone_or_update = Mock(return_value=futurized(None))
+        driver._assure_clone_dir_exists = Mock(return_value=True)
+        driver._load_repo = Mock(return_value=futurized({}))
+        await driver.list_presets()
+        driver._load_repo.assert_has_calls([
+            mock.call('paas', '/tmp/paas'), mock.call('db', '/tmp/db')
+        ])
+        self.assertEqual(driver._load_repo.call_count, 2)
 
     def tearDown(self):
         patch.stopall()


### PR DESCRIPTION
Well, when you start few instances of a vmshpherd on a one virtual machine, then you will find some issues in gitrepo driver.

Like for example:

```

vmshepherd/presets/gitrepo_driver.py", line 64, in _clone_or_update#010    raise RuntimeError(f'Could not fetch presets ({path}) from {repo}')#010RuntimeError: Could not fetch presets (/tmp/XXXX/paas) from http://XXXXXXXXXX.git

```
This fix, will add random name to a directory, so every instance will have a unique preset directory, which solve all problems.

