### PR TITLE
Fix race condition in git plugin for a presets

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+
+1.3.3 (2019-07-26)
+------------------
+
+* bugfix:  Add asyncio.Lock for git clone/pull commands
+
 1.3.2 (2019-07-26)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(name):
 
 setup(
     name="vmshepherd",
-    version="1.3.2",
+    version="1.3.3",
     author='Dreamlab - PaaS KRK',
     author_email='paas-support@dreamlab.pl',
     url='https://github.com/Dreamlab/vmshepherd',

--- a/src/vmshepherd/presets/gitrepo_driver.py
+++ b/src/vmshepherd/presets/gitrepo_driver.py
@@ -59,9 +59,7 @@ class GitRepoDriver(AbstractConfigurationDriver):
                 *cmd, stdout=PIPE, stderr=PIPE
             )
             stdout, stderr = await process.communicate()
-
             logging.debug('GitRepo code=%s stdout: %s stderr: %s', process.returncode, stdout, stderr)
-
             if process.returncode != 0:
                 logging.error('Git error: %s %s %s', path, repo, stderr)
                 raise RuntimeError(f'Could not fetch presets ({path}) from {repo}')

--- a/src/vmshepherd/presets/gitrepo_driver.py
+++ b/src/vmshepherd/presets/gitrepo_driver.py
@@ -48,20 +48,24 @@ class GitRepoDriver(AbstractConfigurationDriver):
         return loaded
 
     async def _clone_or_update(self, path, repo):
-        if os.path.exists(path):
-            cmd = ['git', '-C', path, 'pull']
-        else:
-            cmd = ['git', 'clone', repo, path]
-        process = await asyncio.create_subprocess_exec(
-            *cmd, stdout=PIPE, stderr=PIPE
-        )
-        stdout, stderr = await process.communicate()
+        try:
+            await self.lock.acquire()
+            if os.path.exists(path):
+                cmd = ['git', '-C', path, 'pull']
+            else:
+                cmd = ['git', 'clone', repo, path]
+            process = await asyncio.create_subprocess_exec(
+                *cmd, stdout=PIPE, stderr=PIPE
+            )
+            stdout, stderr = await process.communicate()
 
-        logging.debug('GitRepo code=%s stdout: %s stderr: %s', process.returncode, stdout, stderr)
+            logging.debug('GitRepo code=%s stdout: %s stderr: %s', process.returncode, stdout, stderr)
 
-        if process.returncode != 0:
-            logging.error('Git error: %s %s %s', path, repo, stderr)
-            raise RuntimeError(f'Could not fetch presets ({path}) from {repo}')
+            if process.returncode != 0:
+                logging.error('Git error: %s %s %s', path, repo, stderr)
+                raise RuntimeError(f'Could not fetch presets ({path}) from {repo}')
+        finally:
+            self.lock.release()
 
     def _assure_clone_dir_exists(self):
         try:

--- a/src/vmshepherd/presets/gitrepo_driver.py
+++ b/src/vmshepherd/presets/gitrepo_driver.py
@@ -15,6 +15,7 @@ class GitRepoDriver(AbstractConfigurationDriver):
         self._clone_dir = config.get('clone_dir', tempfile.TemporaryDirectory(prefix='vmshepherd').name)
         self._repos = config['repositories']
         self._specs = {}
+        self.lock = asyncio.Lock()
 
     async def _get_preset_spec(self, preset_name: str):
         return self._specs[preset_name]


### PR DESCRIPTION
Case:

When application starts, we execute few git commands at once, and get errors, like this:

```
[E 190726 16:15:29 gitrepo_driver:37] 
 GitReposDriver: Could not load paas from http://presets-int.git
    Traceback (most recent call last):
      File "/home/pkruk/dl-vmgr/lib/vmshepherd/presets/gitrepo_driver.py", line 69, in _clone_or_update
        raise RuntimeError(f'Could not fetch presets ({path}) from {repo}')
    RuntimeError: Could not fetch presets (/tmp/vmshepherdalnwaeoy/paas) from http://presets-int.git
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/home/pkruk/dl-vmgr/lib/vmshepherd/presets/gitrepo_driver.py", line 33, in reload
        await self._clone_or_update(path, repo)
      File "/home/pkruk/dl-vmgr/lib/vmshepherd/presets/gitrepo_driver.py", line 71, in _clone_or_update
        self.lock.release()
      File "/opt/sdk/python_3.6.1.1_x86_64/lib/python3.6/asyncio/locks.py", line 201, in release
        raise RuntimeError('Lock is not acquired.')
    RuntimeError: Lock is not acquired.
[E 190726 16:15:29 gitrepo_driver:56] [gitrepo_driver]: PULL ['git', '-C', '/tmp/vmshepherdalnwaeoy/paas', 'pull']
[E 190726 16:15:29 gitrepo_driver:37] [gitrepo_driver]: GitReposDriver: Could not load paas from http://presets-int.git

```

Because we are running git clone, and git pull in the same time (Git clone is not finished, and we start git pull which cannot be finished with a success).

So I introduce a locking for this method, so git pull will be executed after clone, not in the same time


