### PR TITLE
bugfix - import not loading under py3.7

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,16 @@
 Changelog
 =========
 
+1.3.4 (2019-07-26)
+------------------
+
+* bugfix:  fix problem with sys.path in drivers
+
 
 1.3.3 (2019-07-26)
 ------------------
 
-* bugfix:  Add asyncio.Lock for git clone/pull commands
+* bugfix:  add asyncio.lock for git clone/pull commands
 
 1.3.2 (2019-07-26)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(name):
 
 setup(
     name="vmshepherd",
-    version="1.3.3",
+    version="1.3.4",
     author='Dreamlab - PaaS KRK',
     author_email='paas-support@dreamlab.pl',
     url='https://github.com/Dreamlab/vmshepherd',

--- a/src/vmshepherd/drivers/__init__.py
+++ b/src/vmshepherd/drivers/__init__.py
@@ -1,5 +1,5 @@
 import json
-from pkg_resources import iter_entry_points
+import pkg_resources
 
 
 class Drivers:
@@ -10,7 +10,7 @@ class Drivers:
     def get(cls, group: str, cfg: dict, **kwargs) -> object:
         _hash = hash(json.dumps(cfg, sort_keys=True))
         if _hash not in cls._loaded:
-            for entry_point in iter_entry_points(group=f'vmshepherd.driver.{group}'):
+            for entry_point in pkg_resources.WorkingSet(None).iter_entry_points(group=f'vmshepherd.driver.{group}'):
                 if entry_point.name == cfg['driver']:
                     _class = entry_point.load()
                     try:


### PR DESCRIPTION
After Migration to pythonv3.7 I cannot load drivers modules.
This fix solve all the problem, and we can iterate over sys.path with adding None to a constructor.
https://stackoverflow.com/questions/22309352/why-does-my-installed-app-handle-pkg-resources-iter-entry-points-differently-tha/25874516