### PR TITLE
remove _initialize_master_working_set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+1.4.2 (2019-08-14)
+------------------
+
+* bugfix: remove next _initialize_master_working_set line
+
+
 1.4.1 (2019-08-14)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(name):
 
 setup(
     name="vmshepherd",
-    version="1.4.1",
+    version="1.4.2",
     author='Dreamlab - PaaS KRK',
     author_email='paas-support@dreamlab.pl',
     url='https://github.com/Dreamlab/vmshepherd',

--- a/src/vmshepherd/drivers/__init__.py
+++ b/src/vmshepherd/drivers/__init__.py
@@ -11,7 +11,6 @@ class Drivers:
     @classmethod
     def get(cls, group: str, cfg: dict, **kwargs) -> object:
         _hash = hash(json.dumps(cfg, sort_keys=True))
-        pkg_resources._initialize_master_working_set()  # reload plugins
         if _hash not in cls._loaded:
             for entry_point in pkg_resources.iter_entry_points(group=f'vmshepherd.driver.{group}'):
                 if entry_point.name == cfg['driver']:


### PR DESCRIPTION
All driver.get reads whole library directory because of pkg_resources._initialize_master_working_set.
